### PR TITLE
Implement RandomAccessBinaryCollection

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,10 @@ jobs:
             rust-version: nightly
       - run: rustup component add llvm-tools-preview
       - run: echo "PATH=/home/runner/.cargo/bin:$PATH" >> $GITHUB_ENV
-      - run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - run: echo "7817b621f62dddfadd35fb84999b441bbce72b70cd8a61a9fe8e0998ccf75898 *grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz" > checksums
+      - run: curl -sOL https://github.com/mozilla/grcov/releases/download/v0.8.6/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz
+      - run: sha256sum -c checksums --ignore-missing
+      - run: tar xf grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz
       - run: cargo test --verbose --workspace
       - run: mkdir ./coverage
       - run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "*cargo*" --ignore "build.rs" --ignore "*target*" --ignore "tests/*" --ignore "*ciff2pisa.rs" --ignore "*pisa2ciff.rs" -o ./coverage/lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ num-traits = "0"
 indicatif = "0.15"
 anyhow = "1.0"
 memmap = "0.7"
+tempfile = "3"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.22"
 
 [dev-dependencies]
-tempfile = "3"
 quickcheck = "1"
 quickcheck_macros = "1"

--- a/src/binary_collection.rs
+++ b/src/binary_collection.rs
@@ -126,7 +126,7 @@ impl<'a> Iterator for BinaryCollection<'a> {
 /// This means [`RandomAccessBinaryCollection::try_from`] will have to
 /// perform one full pass through the entire collection to collect the
 /// offsets. Thus, use this class only if you need the random access
-/// funcionality.
+/// functionality.
 ///
 /// Note that the because offsets are stored within the struct, it is
 /// not `Copy` as opposed to [`BinaryCollection`], which is simply a view

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
     clippy::module_name_repetitions,
     clippy::default_trait_access,
     clippy::cast_possible_wrap,
-    clippy::cast_possible_truncation
+    clippy::cast_possible_truncation,
+    clippy::copy_iterator
 )]
 
 use anyhow::{anyhow, Context};
@@ -37,7 +38,9 @@ use std::path::{Path, PathBuf};
 mod proto;
 pub use proto::{DocRecord, Posting, PostingsList};
 mod binary_collection;
-pub use binary_collection::{BinaryCollection, BinarySequence, InvalidFormat};
+pub use binary_collection::{
+    BinaryCollection, BinarySequence, InvalidFormat, RandomAccessBinaryCollection,
+};
 
 type Result<T> = anyhow::Result<T>;
 

--- a/src/pisa2ciff.rs
+++ b/src/pisa2ciff.rs
@@ -41,7 +41,7 @@ fn main() {
         &args.terms,
         &args.documents,
         &args.output,
-        &args.description.unwrap_or_else(String::new),
+        &args.description.unwrap_or_default(),
     ) {
         eprintln!("ERROR: {}", error);
         std::process::exit(1);

--- a/tests/toy.rs
+++ b/tests/toy.rs
@@ -109,3 +109,79 @@ fn test_to_and_from_ciff() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_reorder_terms() -> anyhow::Result<()> {
+    let input_path = PathBuf::from("tests/test_data/toy-complete-20200309.ciff");
+    let temp = TempDir::new().unwrap();
+    let pisa_path = temp.path().join("coll");
+    ciff_to_pisa(&input_path, &pisa_path)?;
+
+    // Rewrite the terms; later, we will check if the posting lists are in reverse order.
+    std::fs::write(
+        temp.path().join("coll.terms"),
+        vec![
+            "veri", "text", "simpl", "head", "enough", "content", "30", "03", "01",
+        ]
+        .join("\n"),
+    )?;
+
+    let ciff_output_path = temp.path().join("ciff");
+    pisa_to_ciff(
+        &pisa_path,
+        &temp.path().join("coll.terms"),
+        &temp.path().join("coll.documents"),
+        &ciff_output_path,
+        "",
+    )?;
+
+    // Convert back to PISA to verify list order
+    let pisa_copy = temp.path().join("copy");
+    ciff_to_pisa(&ciff_output_path, &pisa_copy)?;
+
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("copy.documents"))?,
+        "WSJ_1\nTREC_DOC_1\nDOC222\n"
+    );
+    assert_eq!(
+        std::fs::read(temp.path().join("coll.sizes"))?,
+        vec![3, 0, 0, 0, 6, 0, 0, 0, 4, 0, 0, 0, 6, 0, 0, 0]
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("copy.terms"))?
+            .lines()
+            .collect::<Vec<_>>(),
+        vec!["01", "03", "30", "content", "enough", "head", "simpl", "text", "veri"]
+    );
+    assert_eq!(
+        std::fs::read(temp.path().join("copy.docs"))?,
+        vec![
+            1, 0, 0, 0, 3, 0, 0, 0, // Number of documents
+            1, 0, 0, 0, 1, 0, 0, 0, // t8
+            3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, // t7
+            2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, // t6
+            3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, // t5
+            1, 0, 0, 0, 2, 0, 0, 0, // t4
+            1, 0, 0, 0, 0, 0, 0, 0, // t3
+            1, 0, 0, 0, 0, 0, 0, 0, // t2
+            1, 0, 0, 0, 0, 0, 0, 0, // t1
+            1, 0, 0, 0, 0, 0, 0, 0, // t0
+        ]
+    );
+    assert_eq!(
+        std::fs::read(temp.path().join("copy.freqs"))?,
+        vec![
+            1, 0, 0, 0, 1, 0, 0, 0, // t8
+            3, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, // t7
+            2, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, // t6
+            3, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, // t5
+            1, 0, 0, 0, 1, 0, 0, 0, // t4
+            1, 0, 0, 0, 1, 0, 0, 0, // t3
+            1, 0, 0, 0, 1, 0, 0, 0, // t2
+            1, 0, 0, 0, 1, 0, 0, 0, // t1
+            1, 0, 0, 0, 1, 0, 0, 0, // t0
+        ]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
RandomAccessBinaryCollection is a wrapper over BinaryCollection that
collects sequence offsets at construction time to allow for random
access.