### PR TITLE
Adding jsonl2ciff

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,8 +72,8 @@ jobs:
         RUSTFLAGS: -Zinstrument-coverage
         LLVM_PROFILE_FILE: coverage-%p-%m.profraw
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
             rust-version: nightly
       - run: rustup component add llvm-tools-preview

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,8 +72,8 @@ jobs:
         RUSTFLAGS: -Zinstrument-coverage
         LLVM_PROFILE_FILE: coverage-%p-%m.profraw
     steps:
-      - uses: actions/checkout@v4
-      - uses: hecrj/setup-rust-action@v2
+      - uses: actions/checkout@v2
+      - uses: hecrj/setup-rust-action@v1
         with:
             rust-version: nightly
       - run: rustup component add llvm-tools-preview

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,8 +40,8 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,8 @@ dependencies = [
  "protobuf-codegen-pure",
  "quickcheck",
  "quickcheck_macros",
+ "serde",
+ "serde_json",
  "structopt",
  "tempfile",
 ]
@@ -159,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +233,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.68",
  "version_check",
 ]
 
@@ -242,11 +250,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -293,14 +301,14 @@ checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.68",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -381,6 +389,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +453,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.68",
 ]
 
 [[package]]
@@ -419,6 +465,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -453,6 +510,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/ciff2pisa.rs"
 name = "pisa2ciff"
 path = "src/pisa2ciff.rs"
 
+[[bin]]
+name = "jsonl2ciff"
+path = "src/jsonl2ciff.rs"
+
 [dependencies]
 protobuf = "^2.27"
 structopt = "0.3"
@@ -27,6 +31,8 @@ indicatif = "0.15"
 anyhow = "1.0"
 memmap = "0.7"
 tempfile = "3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.22"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ To convert a CIFF blob to a PISA canonical:
 To convert a PISA canonical to a CIFF blob:
 `./target/release/pisa2ciff`
 
+To convert a Jsonl file to a CIFF blob:
+`./target/release/jsonl2ciff`
+
+Documents should have the following format. Each line should be a JSON-formatted string with the following fields:
+
+`id`: must represent the ID of the document.
+`content`: the original content of the document, as a string. This field is optional.
+`vector`: a dictionary where each key represents a token, and its corresponding value is the quantized score, e.g., {"ciff": 5}.
+
 ### Install
 
 You can also install the binaries to your local `cargo` repository:

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let out_dir = Path::new(&out_dir_env);
     protobuf_codegen_pure::Codegen::new()
         .out_dir(out_dir)
-        .inputs(&["proto/common-index-format-v1.proto"])
+        .inputs(["proto/common-index-format-v1.proto"])
         .include("proto")
         .run()
         .expect("Codegen failed.");
@@ -22,7 +22,7 @@ fn main() {
                 .write_all(line.as_bytes())
                 .expect("Failed to write to generated file");
             writer
-                .write_all(&[b'\n'])
+                .write_all(b"\n")
                 .expect("Failed to write to generated file");
         }
     }

--- a/src/binary_collection.rs
+++ b/src/binary_collection.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::{self, Write};
 
-const ELEMENT_SIZE: usize = std::mem::size_of::<u32>();
+const ELEMENT_SIZE: usize = size_of::<u32>();
 
 /// Error raised when the bytes cannot be properly parsed into the collection format.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -77,7 +77,7 @@ pub struct BinaryCollection<'a> {
 impl<'a> TryFrom<&'a [u8]> for BinaryCollection<'a> {
     type Error = InvalidFormat;
     fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
-        if bytes.len() % std::mem::size_of::<u32>() == 0 {
+        if bytes.len() % size_of::<u32>() == 0 {
             Ok(Self { bytes })
         } else {
             Err(InvalidFormat::new(
@@ -299,8 +299,8 @@ impl<'a> TryFrom<&'a [u8]> for BinarySequence<'a> {
     /// # }
     /// ```
     fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
-        if bytes.len() % std::mem::size_of::<u32>() == 0 {
-            let length = bytes.len() / std::mem::size_of::<u32>();
+        if bytes.len() % size_of::<u32>() == 0 {
+            let length = bytes.len() / size_of::<u32>();
             Ok(Self { bytes, length })
         } else {
             Err(())
@@ -336,7 +336,7 @@ impl<'a> BinarySequence<'a> {
     #[must_use]
     pub fn get(&self, index: usize) -> Option<u32> {
         if index < self.len() {
-            let offset = index * std::mem::size_of::<u32>();
+            let offset = index * size_of::<u32>();
             self.bytes.get(offset..offset + 4).map(|bytes| {
                 // SAFETY: it is safe because if `get` returns `Some`, the slice must be of length 4.
                 unsafe { bytes_to_u32(bytes) }

--- a/src/binary_collection.rs
+++ b/src/binary_collection.rs
@@ -23,7 +23,7 @@ impl fmt::Display for InvalidFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Invalid binary collection format")?;
         if let Some(msg) = &self.0 {
-            write!(f, ": {}", msg)?;
+            write!(f, ": {msg}")?;
         }
         Ok(())
     }
@@ -534,7 +534,7 @@ mod test {
         let order = vec![0, 1, 4, 9, 5, 6, 7, 2, 3, 8];
         let mut output = Vec::<u8>::new();
         reorder(&coll, &order, &mut output).unwrap();
-        println!("{:?}", output);
+        println!("{output:?}");
         let reordered = BinaryCollection::try_from(output.as_ref()).unwrap();
         let sequences = reordered
             .map(|sequence| {

--- a/src/binary_collection.rs
+++ b/src/binary_collection.rs
@@ -367,7 +367,7 @@ pub struct BinarySequenceIterator<'a> {
     index: usize,
 }
 
-impl<'a> Iterator for BinarySequenceIterator<'a> {
+impl Iterator for BinarySequenceIterator<'_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/ciff2pisa.rs
+++ b/src/ciff2pisa.rs
@@ -40,7 +40,7 @@ fn main() {
         converter.skip_lexicons();
     }
     if let Err(error) = converter.convert() {
-        eprintln!("ERROR: {}", error);
+        eprintln!("ERROR: {error}");
         std::process::exit(1);
     }
 }

--- a/src/jsonl2ciff.rs
+++ b/src/jsonl2ciff.rs
@@ -24,7 +24,7 @@ fn main() {
     converter.input_path(args.input).output_paths(args.output);
 
     if let Err(error) = converter.convert() {
-        eprintln!("ERROR: {}", error);
+        eprintln!("ERROR: {error}");
         std::process::exit(1);
     }
 }

--- a/src/jsonl2ciff.rs
+++ b/src/jsonl2ciff.rs
@@ -1,0 +1,30 @@
+mod proto;
+pub use proto::{DocRecord, Header, Posting, PostingsList};
+
+use ciff::JsonlToCiff;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "pisa2ciff",
+    about = "Convert a PISA index to a Common Index Format [v1]"
+)]
+struct Args {
+    #[structopt(short, long, help = "Path to jsonl file")]
+    input: PathBuf,
+    #[structopt(short, long, help = "Output basename")]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = Args::from_args();
+
+    let mut converter = JsonlToCiff::default();
+    converter.input_path(args.input).output_paths(args.output);
+
+    if let Err(error) = converter.convert() {
+        eprintln!("ERROR: {}", error);
+        std::process::exit(1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 use memmap::Mmap;
 use num_traits::ToPrimitive;
 use protobuf::{CodedInputStream, CodedOutputStream};
+use serde::Deserialize;
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
@@ -770,6 +772,202 @@ fn pisa_to_ciff_from_paths(
     out.flush()?;
 
     Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonDoc {
+    /// CIFF docid (must be an integer). In a typical CIFF index, this is 0..(num_docs-1).
+    id: i32,
+
+    /// Optional textual content for the document.
+    #[serde(default)]
+    content: String,
+
+    /// A dictionary from token (term) to a score (e.g., frequency). This is optional in the JSON.
+    #[serde(default)]
+    vector: HashMap<String, f64>,
+}
+
+/// PISA to CIFF converter.
+#[derive(Debug, Default, Clone)]
+pub struct JsonlToCiff {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+}
+
+impl JsonlToCiff {
+    /// Set the path of the JSONL file. Required.
+    pub fn input_path<P: Into<PathBuf>>(&mut self, path: P) -> &mut Self {
+        self.input = Some(path.into());
+        self
+    }
+
+    /// Set the output CIFF file path. Required.
+    pub fn output_paths<P: Into<PathBuf>>(&mut self, path: P) -> &mut Self {
+        self.output = Some(path.into());
+        self
+    }
+
+    /// Performs the conversion from JSONL to CIFF.
+    ///
+    /// # Errors
+    ///
+    /// If the input / output is invalid or any I/O / parsing error occurs,
+    /// returns an error.
+    pub fn convert(&self) -> Result<()> {
+        let input_path = self
+            .input
+            .as_ref()
+            .ok_or_else(|| anyhow!("No JSON input path was set"))?;
+        let output_path = self
+            .output
+            .as_ref()
+            .ok_or_else(|| anyhow!("No CIFF output path was set"))?;
+
+        // Open the JSONL file
+        let input_file =
+            File::open(input_path).with_context(|| format!("Cannot open {:?}", input_path))?;
+        let total_input_size = input_file.metadata()?.len();
+
+        let reader = BufReader::new(input_file);
+
+        // We'll store doc-level info:
+        let mut doc_records: Vec<DocRecord> = Vec::new();
+
+        // We'll map "term" -> (docid, tf).
+        // Because CIFF uses integer tf, we round any float to i32.
+        let mut postings_map: HashMap<String, Vec<(i32, i32)>> = HashMap::new();
+
+        let mut total_terms_in_collection: i64 = 0;
+        let mut max_docid: i32 = -1;
+
+        // Read JSON lines
+        eprintln!("Read JSON lines");
+        let pb = ProgressBar::new(total_input_size);
+        pb.set_style(pb_style());
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let jdoc: JsonDoc = match serde_json::from_str(&line) {
+                Ok(doc) => doc,
+                Err(e) => {
+                    return Err(anyhow!("Invalid JSON line:\n  `{}`\n  Error: {}", line, e));
+                }
+            };
+
+            if jdoc.id > max_docid {
+                max_docid = jdoc.id;
+            }
+
+            // Sum of tf's in this doc => doc_length
+            let mut doc_length = 0i64;
+            for (term, score) in &jdoc.vector {
+                let tf = score.round() as i32;
+                if tf <= 0 {
+                    continue; // skip zero or negative
+                }
+                doc_length += 1;
+
+                postings_map
+                    .entry(term.clone())
+                    .or_default()
+                    .push((jdoc.id, tf));
+            }
+            total_terms_in_collection += doc_length;
+
+            // Build a DocRecord
+            let mut record = DocRecord::new();
+            record.set_docid(jdoc.id);
+            record.set_collection_docid(jdoc.content.clone());
+            record.set_doclength(doc_length as i32);
+
+            doc_records.push(record);
+            pb.inc(line.len() as u64 + 1);
+        }
+        pb.finish();
+
+        // Sort doc_records by docid
+        doc_records.sort_by_key(|r| r.get_docid());
+        let num_docs = doc_records.len() as i32;
+
+        // Build postings (term -> PostingsList)
+        // 1) collect (docid, tf)
+        // 2) sort by docid
+        // 3) store into a PostingsList with df/cf
+        let mut terms: Vec<(String, Vec<(i32, i32)>)> = postings_map.into_iter().collect();
+        // Sort by term lex order (not required by CIFF, but common)
+        terms.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let num_postings_lists = terms.len() as i32;
+
+        // Build the CIFF Header
+        let mut header = proto::Header::default();
+        header.set_version(1);
+        header.set_num_postings_lists(num_postings_lists);
+        header.set_total_postings_lists(num_postings_lists);
+        header.set_num_docs(num_docs);
+        header.set_total_docs(num_docs);
+        header.set_total_terms_in_collection(total_terms_in_collection);
+        if num_docs > 0 {
+            header.set_average_doclength(total_terms_in_collection as f64 / num_docs as f64);
+        } else {
+            header.set_average_doclength(0.0);
+        }
+        header.set_description("Converted from JSON lines".to_string());
+
+        // Open output CIFF file
+        let output_file = File::create(output_path)
+            .with_context(|| format!("Cannot create output file {:?}", output_path))?;
+        let mut writer = BufWriter::new(output_file);
+        let mut coded_out = CodedOutputStream::new(&mut writer);
+
+        // 1) Write header
+        coded_out.write_message_no_tag(&header)?;
+
+        // 2) Write postings
+        eprintln!("Writing postings");
+        let progress = ProgressBar::new(terms.len() as u64);
+        progress.set_style(pb_style());
+        progress.set_draw_delta(10);
+
+        for (term, mut posting_pairs) in terms {
+            // Sort by docid
+            posting_pairs.sort_by_key(|(docid, _)| *docid);
+
+            let df = posting_pairs.len() as i64;
+            let cf = posting_pairs.iter().map(|(_, tf)| *tf as i64).sum::<i64>();
+
+            let mut postings_list = PostingsList::new();
+            postings_list.set_term(term);
+            postings_list.set_df(df);
+            postings_list.set_cf(cf);
+
+            for (docid, tf) in posting_pairs {
+                let mut posting = Posting::new();
+                posting.set_docid(docid);
+                posting.set_tf(tf);
+                postings_list.postings.push(posting);
+            }
+            coded_out.write_message_no_tag(&postings_list)?;
+            progress.inc(1);
+        }
+        progress.finish();
+
+        // 3) Write doc records
+        for record in doc_records {
+            coded_out.write_message_no_tag(&record)?;
+        }
+
+        coded_out.flush()?;
+        drop(coded_out);
+        writer.flush()?;
+
+        eprintln!(
+            "Wrote {} documents and {} postings lists to {:?}",
+            num_docs, num_postings_lists, output_path
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,13 +41,14 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::all)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::default_trait_access,
     clippy::cast_possible_wrap,
     clippy::cast_possible_truncation,
-    clippy::copy_iterator
+    clippy::copy_iterator,
+    clippy::cast_precision_loss
 )]
 
 use anyhow::{anyhow, Context};
@@ -433,7 +434,7 @@ fn convert_to_pisa(input: &Path, output: &PisaPaths) -> Result<()> {
 
     eprintln!("Processing postings");
     encode_u32_sequence(&mut documents, 1, [header.num_documents].iter())?;
-    let progress = ProgressBar::new(u64::try_from(header.num_postings_lists)?);
+    let progress = ProgressBar::new(u64::from(header.num_postings_lists));
     progress.set_style(pb_style());
     progress.set_draw_delta(10);
     for _ in 0..header.num_postings_lists {

--- a/src/payload_vector.rs
+++ b/src/payload_vector.rs
@@ -54,7 +54,7 @@ where
         }
 
         data.extend(payloads);
-        data[..std::mem::size_of::<u64>()].copy_from_slice(&length.to_le_bytes());
+        data[..size_of::<u64>()].copy_from_slice(&length.to_le_bytes());
 
         Self { data }
     }

--- a/src/pisa2ciff.rs
+++ b/src/pisa2ciff.rs
@@ -44,7 +44,7 @@ fn main() {
         .output_path(args.output)
         .convert()
     {
-        eprintln!("ERROR: {}", error);
+        eprintln!("ERROR: {error}");
         std::process::exit(1);
     }
 }

--- a/src/proto/common_index_format_v1.rs
+++ b/src/proto/common_index_format_v1.rs
@@ -1,7 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 #![allow(clippy::pedantic)]
-#![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -50,7 +50,7 @@ mod test {
         let formatted = format!("{header}");
         assert_eq!(
             formatted,
-            r#"----- CIFF HEADER -----
+            r"----- CIFF HEADER -----
 Version: 1
 No. Postings Lists: 13
 Total Postings Lists: 399
@@ -59,7 +59,7 @@ Total Documents: 200
 Total Terms in Collection 888
 Average Document Length: 12.7
 Description: Test description
------------------------"#
+-----------------------"
         );
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -47,7 +47,7 @@ mod test {
             description: "Test description".to_string(),
             ..Header::default()
         };
-        let formatted = format!("{}", header);
+        let formatted = format!("{header}");
         assert_eq!(
             formatted,
             r#"----- CIFF HEADER -----

--- a/tests/toy.rs
+++ b/tests/toy.rs
@@ -98,8 +98,8 @@ fn test_to_and_from_ciff() -> anyhow::Result<()> {
     let ciff_output_path = temp.path().join("ciff");
     PisaToCiff::default()
         .index_paths(&output_path)
-        .terms_path(&temp.path().join("coll.terms"))
-        .titles_path(&temp.path().join("coll.documents"))
+        .terms_path(temp.path().join("coll.terms"))
+        .titles_path(temp.path().join("coll.documents"))
         .output_path(&ciff_output_path)
         .convert()?;
 
@@ -156,7 +156,7 @@ fn test_reorder_terms() -> anyhow::Result<()> {
     // Rewrite the terms; later, we will check if the posting lists are in reverse order.
     std::fs::write(
         temp.path().join("coll.terms"),
-        vec![
+        [
             "veri", "text", "simpl", "head", "enough", "content", "30", "03", "01",
         ]
         .join("\n"),
@@ -165,8 +165,8 @@ fn test_reorder_terms() -> anyhow::Result<()> {
     let ciff_output_path = temp.path().join("ciff");
     PisaToCiff::default()
         .index_paths(&pisa_path)
-        .terms_path(&temp.path().join("coll.terms"))
-        .titles_path(&temp.path().join("coll.documents"))
+        .terms_path(temp.path().join("coll.terms"))
+        .titles_path(temp.path().join("coll.documents"))
         .output_path(&ciff_output_path)
         .convert()?;
 


### PR DESCRIPTION
This tool allows to convert from the `jsonl` format used these days by learned sparse models into the more standard CIFF.