### PR TITLE
Fix delta encoding, non-integer docids, change function name

### DIFF
--- a/src/jsonl2ciff.rs
+++ b/src/jsonl2ciff.rs
@@ -21,7 +21,7 @@ fn main() {
     let args = Args::from_args();
 
     let mut converter = JsonlToCiff::default();
-    converter.input_path(args.input).output_paths(args.output);
+    converter.input_path(args.input).output_path(args.output);
 
     if let Err(error) = converter.convert() {
         eprintln!("ERROR: {error}");


### PR DESCRIPTION
1. Adds delta encoding to JsonlToCiff
2. Adds support for non-integer collection docids. Currently, I use a hashmap to automatically assign integer docids as new collection docids are encountered. If a collection only has integer docids and the jsonl file is not sorted by docid in ascending order, this can assign different internal docids than expected.
3. Pedantic style change to make JsonlToCiff's `output_paths()` consistent with PisaToCiff's `output_path()`

Fixes pisa-engine/ciff#37